### PR TITLE
Add requirements.txt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -283,12 +283,8 @@ echo -n [*] Instalando requerimientos de python...= ;
 sleep 3 & while [ "$(ps a | awk '{print $1}' | grep $!)" ] ; do for X in '-' '\' '|' '/'; do echo -en "\b$X"; sleep 0.1; done; done
 echo ""
 echo -e $green
-pip3 install requests
-pip3 install py-getch
+pip3 install -r requirements.txt
 apt-get install python3-tk
-pip3 install pathlib
-pip3 install zenipy
-pip3 install pgrep
 apt-get install libatk-adaptor libgail-common
 sudo apt-get purge fcitx-module-dbus
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+py-getch
+python3-tk
+pathlib
+zenipy
+pgrep


### PR DESCRIPTION
Agregar `requirements.txt` donde estará las dependencias de Python. Permite la automatización de la instalación de los paquetes en un solo comando `pip3 install -r requirements.txt` donde este fue también cambiado en el script de instalación.